### PR TITLE
feat(configs) Support new carry board

### DIFF
--- a/debian/etc/board_config.json
+++ b/debian/etc/board_config.json
@@ -98,17 +98,17 @@
     "cameras": [
       {
         "reset": "114:low",
-        "i2c_bus": 1,
-        "mipi_host": 1
-      },
-      {
-        "reset": "114:low",
         "i2c_bus": 3,
         "mipi_host": 0
       },
       {
         "reset": "114:low",
-        "i2c_bus": 3,
+        "i2c_bus": 1,
+        "mipi_host": 1
+      },
+      {
+        "reset": "114:low",
+        "i2c_bus": 0,
         "mipi_host": 2
       }
     ]


### PR DESCRIPTION
    Summary:
            Old: HOST2 <=> I2C3
            New: HOST2 <=> I2C0